### PR TITLE
 List and Selecting the Number of Records per Page  and column order and Move dynamics templates choices from meta field to custom helper methods and validations    

### DIFF
--- a/cjkcms/mixin.py
+++ b/cjkcms/mixin.py
@@ -1,0 +1,147 @@
+# mixins.py
+from django.conf import settings
+from django.contrib.admin.utils import label_for_field
+from django.utils.functional import cached_property
+from wagtail.admin.widgets.button import HeaderButton
+from wagtail.snippets.views.snippets import IndexView as SnippetIndexView
+
+
+class RecordsPerPageMixin:
+    """Adds per-page selection support and exposes list-setup context values."""
+
+    session_key = "wagtail_admin_records_per_page"
+
+    def get_per_page_session_key(self):
+        return self.session_key
+
+    def get_allowed_per_page_values(self):
+        return getattr(
+            settings,
+            "WAGTAIL_ADMIN_PER_PAGE_OPTIONS",
+            [10, 20, 50, 100, 120],
+        )
+
+    def get_default_per_page(self):
+        return getattr(
+            settings,
+            "WAGTAIL_ADMIN_DEFAULT_PER_PAGE",
+            20,
+        )
+
+    def get_paginate_by(self, queryset):
+        allowed_values = self.get_allowed_per_page_values()
+        default_value = self.get_default_per_page()
+        session_key = self.get_per_page_session_key()
+
+        value = self.request.GET.get("per_page")
+
+        if value is not None:
+            try:
+                value = int(value)
+            except ValueError:
+                value = default_value
+
+            if value in allowed_values:
+                self.request.session[session_key] = value
+                return value
+
+        return self.request.session.get(session_key, default_value)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        context["per_page_options"] = self.get_allowed_per_page_values()
+        context["current_per_page"] = self.get_paginate_by(self.get_queryset())
+        context["default_per_page"] = self.get_default_per_page()
+        if hasattr(self, "_all_list_display"):
+            context["all_list_display"] = self._all_list_display
+            selected = self._get_selected_columns()
+            context["selected_list_display"] = selected
+            hidden = [col for col in self._all_list_display if col not in selected]
+            ordered_for_modal = [*selected, *hidden]
+            context["all_list_display_choices"] = [
+                {
+                    "name": column,
+                    "label": self._get_column_label(column),
+                }
+                for column in ordered_for_modal
+            ]
+
+        return context
+
+    def _get_column_label(self, column_name):
+        try:
+            label = label_for_field(column_name, self.model)
+        except Exception:
+            label = column_name.replace("_", " ")
+        return str(label)
+
+
+class RecordsPerPageSnippetIndexView(RecordsPerPageMixin, SnippetIndexView):
+    """Snippet index view with per-model column visibility and list setup button."""
+
+    template_name = "wagtailsnippets/snippets/list_with_setup.html"
+    columns_session_prefix = "wagtail_admin_visible_columns"
+    per_page_session_prefix = "wagtail_admin_records_per_page"
+
+    def _model_key(self):
+        return f"{self.model._meta.app_label}.{self.model._meta.model_name}"
+
+    def get_per_page_session_key(self):
+        return f"{self.per_page_session_prefix}:{self._model_key()}"
+
+    def get_columns_session_key(self):
+        return f"{self.columns_session_prefix}:{self._model_key()}"
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self._all_list_display = [
+            column for column in list(self.list_display) if isinstance(column, str)
+        ]
+        self._apply_selected_columns()
+
+    def _sanitize_columns(self, columns):
+        if not columns:
+            return []
+        allowed = set(self._all_list_display)
+        selected = []
+        seen = set()
+        for column in columns:
+            if column in allowed and column not in seen:
+                selected.append(column)
+                seen.add(column)
+        return selected
+
+    def _get_selected_columns(self):
+        session_key = self.get_columns_session_key()
+        value = self.request.GET.get("cols")
+
+        if value is not None:
+            requested = [item.strip() for item in value.split(",") if item.strip()]
+            selected = self._sanitize_columns(requested)
+            if selected:
+                self.request.session[session_key] = selected
+                return selected
+            self.request.session.pop(session_key, None)
+            return self._all_list_display
+
+        stored = self.request.session.get(session_key, self._all_list_display)
+        selected = self._sanitize_columns(stored)
+        return selected or self._all_list_display
+
+    def _apply_selected_columns(self):
+        self.list_display = self._get_selected_columns()
+
+    @cached_property
+    def header_buttons(self):
+        buttons = list(super().header_buttons)
+        buttons.append(
+            HeaderButton(
+                "List setup",
+                url="#",
+                icon_name="cogs",
+                attrs={"id": "list-setup-open", "aria-label": "Open list setup"},
+                priority=20,
+            )
+        )
+        return buttons

--- a/cjkcms/models/page_models.py
+++ b/cjkcms/models/page_models.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
 # import geocoder
 from django import forms
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, InvalidPage, PageNotAnInteger, Paginator
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -26,6 +27,7 @@ from wagtail.admin.panels import (
     ObjectList,
     TabbedInterface,
 )
+from wagtail.admin.forms import WagtailAdminPageForm
 from wagtail.coreutils import resolve_model_string
 from wagtail.fields import StreamField
 from wagtail.images import get_image_model_string
@@ -53,6 +55,18 @@ CJKCMS_PAGE_MODELS: List[Type[Page]] = []
 
 def get_page_models() -> List[Type[Page]]:
     return CJKCMS_PAGE_MODELS
+
+
+class CjkcmsPageAdminForm(WagtailAdminPageForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        model = self._meta.model
+
+        if "custom_template" in self.fields:
+            self.fields["custom_template"].choices = model.get_custom_template_choices()
+
+        if "index_order_by" in self.fields:
+            self.fields["index_order_by"].choices = model.get_index_order_by_choices()
 
 
 class CjkcmsPageMeta(PageBase):
@@ -84,6 +98,7 @@ class CjkcmsPage(WagtailCacheMixin, SeoMixin, Page, metaclass=CjkcmsPageMeta):
 
     # Do not allow this page type to be created in wagtail admin
     is_creatable = False
+    base_form_class = CjkcmsPageAdminForm
 
     # Templates
     # The page will render the following templates under certain conditions:
@@ -319,23 +334,50 @@ class CjkcmsPage(WagtailCacheMixin, SeoMixin, Page, metaclass=CjkcmsPageMeta):
 
     integration_panels = []
 
+    @classmethod
+    def get_custom_template_choices(cls):
+        class_name = cls.__name__.lower()
+        return cms_settings.CJKCMS_FRONTEND_TEMPLATES_PAGES.get("*", []) + (
+            cms_settings.CJKCMS_FRONTEND_TEMPLATES_PAGES.get(class_name, [])
+        )
+
+    @classmethod
+    def get_index_order_by_choices(cls):
+        return cls.index_order_by_choices
+
     def __init__(self, *args, **kwargs):
         """
         Inject custom choices and defaults into the form fields
         to enable customization by subclasses.
         """
         super().__init__(*args, **kwargs)
-        klassname = self.__class__.__name__.lower()
-        template_choices = cms_settings.CJKCMS_FRONTEND_TEMPLATES_PAGES.get(
-            "*", []
-        ) + cms_settings.CJKCMS_FRONTEND_TEMPLATES_PAGES.get(klassname, [])
-
-        self._meta.get_field("index_order_by").choices = self.index_order_by_choices  # type: ignore
-        self._meta.get_field("custom_template").choices = template_choices  # type: ignore
         if not self.id:  # type: ignore
             self.index_order_by = self.index_order_by_default
             self.index_show_subpages = self.index_show_subpages_default
             self.related_show = self.related_show_default
+
+    def clean(self):
+        super().clean()
+
+        valid_templates = {value for value, _ in self.get_custom_template_choices()}
+        if self.custom_template not in valid_templates:
+            raise ValidationError(
+                {
+                    "custom_template": [
+                        f"Value {self.custom_template!r} is not a valid choice."
+                    ]
+                }
+            )
+
+        valid_ordering = {value for value, _ in self.get_index_order_by_choices()}
+        if self.index_order_by not in valid_ordering:
+            raise ValidationError(
+                {
+                    "index_order_by": [
+                        f"Value {self.index_order_by!r} is not a valid choice."
+                    ]
+                }
+            )
 
     @classmethod
     def get_panels(cls):  # sourcery skip: instance-method-first-arg-name

--- a/cjkcms/static/cjkcms/js/list-setup.js
+++ b/cjkcms/static/cjkcms/js/list-setup.js
@@ -1,0 +1,97 @@
+(function () {
+    function initListSetup() {
+        const openBtn = document.getElementById('list-setup-open');
+        const modal = document.getElementById('list-setup-modal');
+        const closeBtn = document.getElementById('list-setup-close');
+        const applyBtn = document.getElementById('list-setup-apply');
+        const resetBtn = document.getElementById('list-setup-reset');
+        const list = document.getElementById('list-setup-columns');
+        const perPageSelect = document.getElementById('list-setup-per-page');
+
+        if (!openBtn || !modal || !applyBtn || !list) {
+            return;
+        }
+
+        openBtn.addEventListener('click', function (e) {
+            e.preventDefault();
+            modal.style.display = 'block';
+        });
+
+        if (closeBtn) {
+            closeBtn.addEventListener('click', function () {
+                modal.style.display = 'none';
+            });
+        }
+
+        modal.addEventListener('click', function (e) {
+            if (e.target === modal) {
+                modal.style.display = 'none';
+            }
+        });
+
+        let dragged = null;
+        list.querySelectorAll('li').forEach(function (item) {
+            item.addEventListener('dragstart', function () {
+                dragged = item;
+                item.style.opacity = '0.6';
+            });
+            item.addEventListener('dragend', function () {
+                item.style.opacity = '1';
+            });
+            item.addEventListener('dragover', function (e) {
+                e.preventDefault();
+            });
+            item.addEventListener('drop', function (e) {
+                e.preventDefault();
+                if (!dragged || dragged === item) {
+                    return;
+                }
+                const rect = item.getBoundingClientRect();
+                const before = (e.clientY - rect.top) < (rect.height / 2);
+                if (before) {
+                    list.insertBefore(dragged, item);
+                } else {
+                    list.insertBefore(dragged, item.nextSibling);
+                }
+            });
+        });
+
+        applyBtn.addEventListener('click', function () {
+            const selected = [];
+            list.querySelectorAll('li').forEach(function (li) {
+                const checkbox = li.querySelector('input[type="checkbox"]');
+                if (checkbox && checkbox.checked) {
+                    selected.push(li.dataset.col);
+                }
+            });
+
+            const url = new URL(window.location.href);
+            url.searchParams.delete('p');
+            if (selected.length) {
+                url.searchParams.set('cols', selected.join(','));
+            } else {
+                url.searchParams.delete('cols');
+            }
+            if (perPageSelect && perPageSelect.value) {
+                url.searchParams.set('per_page', perPageSelect.value);
+            }
+            window.location.href = url.toString();
+        });
+
+        if (resetBtn) {
+            resetBtn.addEventListener('click', function () {
+                const url = new URL(window.location.href);
+                url.searchParams.delete('p');
+                url.searchParams.delete('cols');
+                url.searchParams.delete('per_page');
+                window.location.href = url.toString();
+            });
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initListSetup);
+    } else {
+        initListSetup();
+    }
+})();

--- a/cjkcms/templates/wagtailsnippets/snippets/list_with_setup.html
+++ b/cjkcms/templates/wagtailsnippets/snippets/list_with_setup.html
@@ -3,16 +3,16 @@
 
 {% block listing %}
     <div id="list-setup-modal" style="display:none;position:fixed;inset:0;z-index:1200;background:rgba(0,0,0,0.45);">
-        <div style="background:#fff;max-width:780px;width:95%;margin:4rem auto;padding:1.25rem;border-radius:8px;max-height:80vh;overflow:auto;">
+        <div style="background:var(--w-color-surface-page);color:var(--w-color-text-context);max-width:780px;width:95%;margin:2rem auto;padding:1.25rem;border:1px solid var(--w-color-border-furniture);border-radius:8px;max-height:calc(100vh - 4rem);overflow:auto;box-sizing:border-box;">
             <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.75rem;">
-                <h2 style="margin:0;font-size:1.5rem;">List Setup</h2>
+                <h2 style="color:inherit;margin:0;font-size:1.5rem;">List Setup</h2>
                 <button type="button" id="list-setup-close" class="button button-secondary">Close</button>
             </div>
             <p style="margin:0 0 0.75rem 0;">Use checkboxes to select columns you want to see. You can change position by dragging rows up or down.</p>
 
-            <ul id="list-setup-columns" style="list-style:none;padding:0;margin:0;border:1px solid #d9d9d9;border-radius:6px;">
+            <ul id="list-setup-columns" style="list-style:none;padding:0;margin:0;border:1px solid var(--w-color-border-furniture);border-radius:6px;">
                 {% for column in all_list_display_choices %}
-                    <li draggable="true" data-col="{{ column.name }}" style="display:flex;align-items:center;gap:0.5rem;padding:0.65rem 0.75rem;border-bottom:1px solid #ededed;cursor:grab;">
+                    <li draggable="true" data-col="{{ column.name }}" style="display:flex;align-items:center;gap:0.5rem;padding:0.65rem 0.75rem;border-bottom:1px solid var(--w-color-border-furniture);cursor:grab;">
                         <span style="opacity:0.6;">☰</span>
                         <label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer;">
                             <input type="checkbox" {% if column.name in selected_list_display %}checked{% endif %}>
@@ -23,7 +23,7 @@
             </ul>
 
             <div style="margin-top:1rem;">
-                <h3 style="margin:0 0 0.5rem 0;font-size:1.1rem;">Records Per Page</h3>
+                <h3 style="color:inherit;margin:0 0 0.5rem 0;font-size:1.1rem;">Records Per Page</h3>
                 <p style="margin:0 0 0.5rem 0;">Select how many records to display on one page.</p>
                 <select id="list-setup-per-page" style="min-width:220px;">
                     {% for option in per_page_options %}

--- a/cjkcms/templates/wagtailsnippets/snippets/list_with_setup.html
+++ b/cjkcms/templates/wagtailsnippets/snippets/list_with_setup.html
@@ -1,0 +1,47 @@
+{% extends "wagtailsnippets/snippets/index.html" %}
+{% load wagtailadmin_tags %}
+
+{% block listing %}
+    <div id="list-setup-modal" style="display:none;position:fixed;inset:0;z-index:1200;background:rgba(0,0,0,0.45);">
+        <div style="background:#fff;max-width:780px;width:95%;margin:4rem auto;padding:1.25rem;border-radius:8px;max-height:80vh;overflow:auto;">
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.75rem;">
+                <h2 style="margin:0;font-size:1.5rem;">List Setup</h2>
+                <button type="button" id="list-setup-close" class="button button-secondary">Close</button>
+            </div>
+            <p style="margin:0 0 0.75rem 0;">Use checkboxes to select columns you want to see. You can change position by dragging rows up or down.</p>
+
+            <ul id="list-setup-columns" style="list-style:none;padding:0;margin:0;border:1px solid #d9d9d9;border-radius:6px;">
+                {% for column in all_list_display_choices %}
+                    <li draggable="true" data-col="{{ column.name }}" style="display:flex;align-items:center;gap:0.5rem;padding:0.65rem 0.75rem;border-bottom:1px solid #ededed;cursor:grab;">
+                        <span style="opacity:0.6;">☰</span>
+                        <label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer;">
+                            <input type="checkbox" {% if column.name in selected_list_display %}checked{% endif %}>
+                            <span>{{ column.label }}</span>
+                        </label>
+                    </li>
+                {% endfor %}
+            </ul>
+
+            <div style="margin-top:1rem;">
+                <h3 style="margin:0 0 0.5rem 0;font-size:1.1rem;">Records Per Page</h3>
+                <p style="margin:0 0 0.5rem 0;">Select how many records to display on one page.</p>
+                <select id="list-setup-per-page" style="min-width:220px;">
+                    {% for option in per_page_options %}
+                        <option value="{{ option }}" {% if option == current_per_page %}selected{% endif %}>{{ option }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+
+            <div style="display:flex;gap:0.5rem;justify-content:flex-end;margin-top:1rem;">
+                <button type="button" id="list-setup-reset" class="button button-secondary">Reset</button>
+                <button type="button" id="list-setup-apply" class="button button-primary">Apply</button>
+            </div>
+        </div>
+    </div>
+    {{ block.super }}
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    <script defer src="{% versioned_static 'cjkcms/js/list-setup.js' %}"></script>
+{% endblock %}


### PR DESCRIPTION
Selecting Columns You Want to See in the List and Selecting the Number of Records per Page in the Administration Panel 
https://github.com/ic-thr/wagtail-thrdb/issues/3       
 
move dynamics templates choices from meta field to custom helper methods and validations    

his change was needed because mutating _meta.get_field(...).choices in __init__ modifies shared field objects at runtime. In practice, that allowed one page model instance to overwrite the valid choices for another model, which made behavior depend on instantiation order and caused failures such as copy_for_translation() rejecting values that were actually valid for the source page type